### PR TITLE
fix: correct 'occured' to 'occurred' in error message

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -107,7 +107,7 @@ export default class GraphAnalysisPlugin extends Plugin {
     } catch (error) {
       console.log(error)
       new Notice(
-        'An error occured with Graph Analysis, please check the console.'
+        'An error occurred with Graph Analysis, please check the console.'
       )
     }
   }


### PR DESCRIPTION
## Summary
Fixes a typo in the user-facing error message in `src/main.ts:110`.

## Change
- `occured` → `occurred` in the Notice() call shown when Graph Analysis encounters an error

## Type
User-facing error message typo fix in Obsidian plugin.